### PR TITLE
callback log entry safe dump

### DIFF
--- a/models/CallbackLogEntry.php
+++ b/models/CallbackLogEntry.php
@@ -15,11 +15,23 @@ class CallbackLogEntry extends ActiveRecord
 {
     public function setRequest($data)
     {
-        $this->requestDump = var_export($data, true);
+        try {
+            $requestDump = var_export($data, true);
+        }
+        catch (\Throwable $e) {
+            $requestDump = print_r($data, true);
+        }
+        $this->requestDump = $requestDump;
     }
 
     public function setResponse($data)
     {
-        $this->responseDump = var_export($data, true);
+        try {
+            $responseDump = var_export($data, true);
+        }
+        catch (\Throwable $e) {
+            $responseDump = print_r($data, true);
+        }
+        $this->responseDump = $responseDump;
     }
 }


### PR DESCRIPTION
Dump request/response data with 'print_r' in case of cyclic dependencies in $data (e.g. Exceptions)